### PR TITLE
AnnotatedMeter takes valueFormatter func

### DIFF
--- a/src/js/components/AnnotatedMeter.js
+++ b/src/js/components/AnnotatedMeter.js
@@ -124,5 +124,7 @@ AnnotatedMeter.propTypes = {
 };
 
 AnnotatedMeter.defaultProps = {
-  valueFormatter: function(value) { return value; }
+  valueFormatter: function(value) {
+    return value;
+  }
 };

--- a/src/js/components/AnnotatedMeter.js
+++ b/src/js/components/AnnotatedMeter.js
@@ -25,7 +25,8 @@ export default class AnnotatedMeter extends Component {
   }
 
   render () {
-    const { legend, max, series, size, type, units, valueFormatter } = this.props;
+    const { legend, max, series, size, type, units, valueFormatter } =
+      this.props;
     const { index } = this.state;
 
     let value, label;
@@ -44,7 +45,8 @@ export default class AnnotatedMeter extends Component {
       top = (
         <Box direction='row' justify='between' align='center'
           pad={{ between: 'small' }} responsive={false}>
-          <Value value={valueFormatter(value)} units={units} align='start' size={size} />
+          <Value value={valueFormatter(value)} units={units} align='start'
+            size={size} />
           <span>{label}</span>
         </Box>
       );
@@ -62,8 +64,8 @@ export default class AnnotatedMeter extends Component {
       middle = (
         <Meter type='circle' stacked={true} series={series}
           label={
-            <Value value={valueFormatter(value)} units={units} align='center' label={label}
-              size={size} />
+            <Value value={valueFormatter(value)} units={units} align='center'
+              label={label} size={size} />
           } max={max} size={size} activeIndex={index}
           onActive={this._onActive} />
       );

--- a/src/js/components/AnnotatedMeter.js
+++ b/src/js/components/AnnotatedMeter.js
@@ -125,4 +125,4 @@ AnnotatedMeter.propTypes = {
 
 AnnotatedMeter.defaultProps = {
   valueFormatter: function(value) { return value; }
-}
+};

--- a/src/js/components/AnnotatedMeter.js
+++ b/src/js/components/AnnotatedMeter.js
@@ -25,7 +25,7 @@ export default class AnnotatedMeter extends Component {
   }
 
   render () {
-    const { legend, max, series, size, type, units } = this.props;
+    const { legend, max, series, size, type, units, valueFormatter } = this.props;
     const { index } = this.state;
 
     let value, label;
@@ -44,7 +44,7 @@ export default class AnnotatedMeter extends Component {
       top = (
         <Box direction='row' justify='between' align='center'
           pad={{ between: 'small' }} responsive={false}>
-          <Value value={value} units={units} align='start' size={size} />
+          <Value value={valueFormatter(value)} units={units} align='start' size={size} />
           <span>{label}</span>
         </Box>
       );
@@ -62,7 +62,7 @@ export default class AnnotatedMeter extends Component {
       middle = (
         <Meter type='circle' stacked={true} series={series}
           label={
-            <Value value={value} units={units} align='center' label={label}
+            <Value value={valueFormatter(value)} units={units} align='center' label={label}
               size={size} />
           } max={max} size={size} activeIndex={index}
           onActive={this._onActive} />
@@ -117,5 +117,10 @@ AnnotatedMeter.propTypes = {
   })).isRequired,
   size: Meter.propTypes.size,
   type: PropTypes.oneOf(['bar', 'circle']).isRequired,
-  units: PropTypes.string
+  units: PropTypes.string,
+  valueFormatter: PropTypes.func
 };
+
+AnnotatedMeter.defaultProps = {
+  valueFormatter: function(value) { return value; }
+}


### PR DESCRIPTION
I have NOT tested this yet, but instead am putting it out for general review before I go to far.

The purpose of the patch is to allow for specifying a formatting function for the value, so it can display, e.g. "$12,345" instead of "12345" (since the value is required to be a number).  I'm looking forward to discussion on naming, etc.  We're finding a similar patch (to an older version) pretty useful.