### PR TITLE
Selected sort arrows indicate selected option in Sort component

### DIFF
--- a/src/js/components/Sort.js
+++ b/src/js/components/Sort.js
@@ -29,7 +29,6 @@ export default class Sort extends Component {
 
   render () {
     const { options, value, ...props } = this.props;
-    delete props.direction;
     let label;
     if (value) {
       label = options.filter(option => option.value === value)[0].label;
@@ -40,10 +39,11 @@ export default class Sort extends Component {
         responsive={false}>
         <Select value={label} options={options} onChange={this._onChange} />
         <Box direction='row' flex={false} responsive={false} align='center'>
-          <Button icon={<AscIcon />}
+          <Button
+            icon={<AscIcon colorIndex={props.direction === 'asc' ? 'brand' : null} />}
             onClick={this._onChangeDirection.bind(this, 'asc')} />
           <Button
-            icon={<DescIcon />}
+            icon={<DescIcon colorIndex={props.direction === 'desc' ? 'brand' : null}/>}
             onClick={this._onChangeDirection.bind(this, 'desc')} />
         </Box>
       </Box>

--- a/src/js/components/Sort.js
+++ b/src/js/components/Sort.js
@@ -28,7 +28,7 @@ export default class Sort extends Component {
   }
 
   render () {
-    const { options, value, ...props } = this.props;
+    const { options, value, direction, ...props } = this.props;
     let label;
     if (value) {
       label = options.filter(option => option.value === value)[0].label;
@@ -41,11 +41,11 @@ export default class Sort extends Component {
         <Box direction='row' flex={false} responsive={false} align='center'>
           <Button
             icon={<AscIcon
-                colorIndex={props.direction === 'asc' ? 'brand' : null} />}
+                colorIndex={direction === 'asc' ? 'brand' : undefined} />}
             onClick={this._onChangeDirection.bind(this, 'asc')} />
           <Button
             icon={<DescIcon
-                colorIndex={props.direction === 'desc' ? 'brand' : null} />}
+                colorIndex={direction === 'desc' ? 'brand' : undefined} />}
             onClick={this._onChangeDirection.bind(this, 'desc')} />
         </Box>
       </Box>

--- a/src/js/components/Sort.js
+++ b/src/js/components/Sort.js
@@ -40,10 +40,12 @@ export default class Sort extends Component {
         <Select value={label} options={options} onChange={this._onChange} />
         <Box direction='row' flex={false} responsive={false} align='center'>
           <Button
-            icon={<AscIcon colorIndex={props.direction === 'asc' ? 'brand' : null} />}
+            icon={<AscIcon
+                colorIndex={props.direction === 'asc' ? 'brand' : null} />}
             onClick={this._onChangeDirection.bind(this, 'asc')} />
           <Button
-            icon={<DescIcon colorIndex={props.direction === 'desc' ? 'brand' : null}/>}
+            icon={<DescIcon
+                colorIndex={props.direction === 'desc' ? 'brand' : null} />}
             onClick={this._onChangeDirection.bind(this, 'desc')} />
         </Box>
       </Box>


### PR DESCRIPTION
Issue: Sort component did not show which direction was selected.
Fix: Added visual hint of which direction is selected by giving the arrows 'brand' color index
Testing done: Manually tested the Sort component
Backwards compatibility: The component should be backwards compatible (it is using the already existing properties and they are not required)