### PR TITLE
Fix for #5

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,11 @@
     "type": "git",
     "url": "https://github.com/grommet/grommet-addons.git"
   },
+  "dependencies": {
+    "react-router": "^3.0.0"
+  },
   "peerDependencies": {
-    "grommet": ">=1.4.0",
-    "react-router": ">=3.0.0"
+    "grommet": ">=1.4.0"
   },
   "devDependencies": {
     "babel-plugin-add-module-exports": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "type": "git",
     "url": "https://github.com/grommet/grommet-addons.git"
   },
-  "dependencies": {
-    "grommet": "https://github.com/grommet/grommet/tarball/stable",
-    "react-router": "^3.0.0"
+  "peerDependencies": {
+    "grommet": ">=1.4.0",
+    "react-router": ">=3.0.0"
   },
   "devDependencies": {
     "babel-plugin-add-module-exports": "^0.2.1",


### PR DESCRIPTION
Moved grommet to peer dependency as per #5. React router still tricky for people who use rr 2.8 which is allowed by grommet.