### PR TITLE
Show spinner for filteredTotal of null, as well as undefined. Fix for issue #10.

### DIFF
--- a/__tests__/components/__snapshots__/Sort-test.js.snap
+++ b/__tests__/components/__snapshots__/Sort-test.js.snap
@@ -13,6 +13,7 @@ exports[`Sort has correct default options 1`] = `
       className="grommetux-input grommetux-select__input"
       placeholder={undefined}
       readOnly={true}
+      type="text"
       value="" />
     <button
       aria-label="Select Icon"

--- a/src/js/components/ListPlaceholder.js
+++ b/src/js/components/ListPlaceholder.js
@@ -14,7 +14,7 @@ export default class ListPlaceholder extends Component {
     } = this.props;
 
     let content1, content2;
-    if (undefined === filteredTotal) {
+    if (!filteredTotal) {
       content1 = <SpinningIcon />;
     } else if (unfilteredTotal === 0) {
       content1 = <span className='secondary'>{emptyMessage}</span>;


### PR DESCRIPTION
Also, updated snapshot for Sort-test to fix broken test, due to TextInput was modified to include type.
