### PR TITLE
Fix grommet-addons issue #3 - Center the circle in the annotated meter all the time.

### DIFF
--- a/__tests__/components/AnnotatedMeter-test.js
+++ b/__tests__/components/AnnotatedMeter-test.js
@@ -10,9 +10,19 @@ import AnnotatedMeter from '../../src/js/components/AnnotatedMeter';
 jest.mock('react-dom');
 
 describe('AnnotatedMeter', () => {
-  it('has correct simple options', () => {
+  it('has correct simple options - bar', () => {
     const component = renderer.create(
       <AnnotatedMeter type='bar' series={[
+        { label: 'label-1', value: 10 },
+        { label: 'label-2', value: 20 }
+      ]}/>
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+    it('has correct simple options - circle', () => {
+    const component = renderer.create(
+      <AnnotatedMeter type='circle' series={[
         { label: 'label-1', value: 10 },
         { label: 'label-2', value: 20 }
       ]}/>

--- a/__tests__/components/__snapshots__/AnnotatedMeter-test.js.snap
+++ b/__tests__/components/__snapshots__/AnnotatedMeter-test.js.snap
@@ -1,4 +1,4 @@
-exports[`AnnotatedMeter has correct simple options 1`] = `
+exports[`AnnotatedMeter has correct simple options - bar 1`] = `
 <div
   className="grommetux-box grommetux-box--direction-column grommetux-box--align-start grommetux-box--responsive grommetux-box--pad-none"
   id={undefined}
@@ -7,7 +7,7 @@ exports[`AnnotatedMeter has correct simple options 1`] = `
   style={Object {}}
   tabIndex={undefined}>
   <div
-    className="grommetux-box grommetux-box--direction-column grommetux-box--responsive grommetux-box--pad-none"
+    className="grommetux-box grommetux-box--direction-column grommetux-box--align-start grommetux-box--responsive grommetux-box--pad-none"
     id={undefined}
     onClick={undefined}
     role={undefined}
@@ -111,6 +111,122 @@ exports[`AnnotatedMeter has correct simple options 1`] = `
               </g>
             </g>
           </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AnnotatedMeter has correct simple options - circle 1`] = `
+<div
+  className="grommetux-box grommetux-box--direction-column grommetux-box--align-start grommetux-box--responsive grommetux-box--pad-none"
+  id={undefined}
+  onClick={undefined}
+  role={undefined}
+  style={Object {}}
+  tabIndex={undefined}>
+  <div
+    className="grommetux-box grommetux-box--direction-column grommetux-box--align-center grommetux-box--responsive grommetux-box--pad-none"
+    id={undefined}
+    onClick={undefined}
+    role={undefined}
+    style={Object {}}
+    tabIndex={undefined}>
+    <div
+      className="grommetux-meter grommetux-meter--circle grommetux-meter--stacked grommetux-meter--count-2">
+      <div
+        className="grommetux-meter__value-container">
+        <div
+          className="grommetux-meter__graphic-container">
+          <svg
+            aria-label="Circle Meter. , Value: 30, Max: 100"
+            className="grommetux-meter__graphic"
+            height={192}
+            onBlur={[Function]}
+            onFocus={[Function]}
+            preserveAspectRatio="xMidYMid meet"
+            role="group"
+            tabIndex="0"
+            viewBox="0 0 192 192"
+            width={192}>
+            <g
+              className="grommetux-meter__tracks">
+              <g>
+                <path
+                  className="grommetux-meter__slice"
+                  d="M 96.0146607656 179.9999987206 A 84.0000000000 84.0000000000 0 1 0 96.0000000000 180.0000000000"
+                  data-index={0}
+                  onBlur={[Function]}
+                  onFocus={[Function]} />
+                <path
+                  className="grommetux-meter__hot"
+                  d="M 96.0146607656 179.9999987206 A 84.0000000000 84.0000000000 0 1 0 96.0000000000 180.0000000000"
+                  fill="none"
+                  onClick={undefined}
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]} />
+              </g>
+            </g>
+            <g
+              className="grommetux-meter__values">
+              <g
+                aria-label="10"
+                role="img">
+                <path
+                  className="grommetux-meter__slice grommetux-color-index-graph-1"
+                  d="M 46.6260388074 163.9574275275 A 84.0000000000 84.0000000000 0 0 0 96.0000000000 180.0000000000"
+                  data-index={0}
+                  onBlur={[Function]}
+                  onFocus={[Function]} />
+                <path
+                  className="grommetux-meter__hot"
+                  d="M 46.6260388074 163.9574275275 A 84.0000000000 84.0000000000 0 0 0 96.0000000000 180.0000000000"
+                  fill="none"
+                  onClick={undefined}
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]} />
+              </g>
+              <g
+                aria-label="20"
+                role="img">
+                <path
+                  className="grommetux-meter__slice grommetux-color-index-graph-2"
+                  d="M 16.1112526312 70.0425724725 A 84.0000000000 84.0000000000 0 0 0 46.6260388074 163.9574275275"
+                  data-index={1}
+                  onBlur={[Function]}
+                  onFocus={[Function]} />
+                <path
+                  className="grommetux-meter__hot"
+                  d="M 16.1112526312 70.0425724725 A 84.0000000000 84.0000000000 0 0 0 46.6260388074 163.9574275275"
+                  fill="none"
+                  onClick={undefined}
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]} />
+              </g>
+            </g>
+          </svg>
+        </div>
+        <div
+          className="grommetux-meter__label">
+          <div
+            className="grommetux-value grommetux-value--align-center">
+            <div
+              className="grommetux-value__annotated">
+              <div>
+                <span
+                  className="grommetux-value__value">
+                  30
+                </span>
+              </div>
+            </div>
+            <span
+              className="grommetux-value__label">
+              <span>
+                Total
+              </span>
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/js/components/AnnotatedMeter.js
+++ b/src/js/components/AnnotatedMeter.js
@@ -39,7 +39,7 @@ export default class AnnotatedMeter extends Component {
       label = <FormattedMessage id='Total' defaultMessage='Total' />;
     }
 
-    let top, middle, bottom, alignLegend;
+    let top, middle, bottom, alignMeter, alignLegend;
     if ('bar' === type) {
 
       top = (
@@ -56,6 +56,7 @@ export default class AnnotatedMeter extends Component {
           onActive={this._onActive} />
       );
 
+      alignMeter = 'start';   
       alignLegend = 'start';
 
     } else if ('circle' === type) {
@@ -69,6 +70,7 @@ export default class AnnotatedMeter extends Component {
           onActive={this._onActive} />
       );
 
+      alignMeter='center';
       alignLegend = 'center';
     }
 
@@ -94,7 +96,7 @@ export default class AnnotatedMeter extends Component {
 
     return (
       <Box align='start'>
-        <Box>
+        <Box align={alignMeter}>
           {top}
           {middle}
           {bottom}


### PR DESCRIPTION
The circle was left justified in all of the browsers, regardless of the label length. The circle looks better visually when it's centered above the legend. Left the bar meter left justified.

Added unit test for the circle meter and updated snapshots.