### PR TITLE
AnnotatedMeter: Proper prop type for onActive.

### DIFF
--- a/src/js/components/AnnotatedMeter.js
+++ b/src/js/components/AnnotatedMeter.js
@@ -109,7 +109,7 @@ export default class AnnotatedMeter extends Component {
 };
 
 AnnotatedMeter.propTypes = {
-  onActive: PropTypes.number,
+  onActive: PropTypes.func,
   legend: PropTypes.bool,
   max: PropTypes.number,
   series: PropTypes.arrayOf(PropTypes.shape({


### PR DESCRIPTION
Fixing warning with invalid value supplied to `onActive` property.

```
Warning: Failed prop type: Invalid prop `onActive` of type `function` supplied to `AnnotatedMeter`, expected `number`.
```